### PR TITLE
Improve representation of small values

### DIFF
--- a/www/res/common.js
+++ b/www/res/common.js
@@ -32,7 +32,7 @@ function adjNum(n, decimals) {
 	if (an >= 100000) return n.toFixed(0);
 	else if (an >= 100) return n.toFixed(2);
 	else if (an >= 1) return n.toFixed(4);
-	else if (an > 0.0001) return n.toFixed(6);
+	else if (an >= 0.000001) return n.toFixed(6);
 	else {
 		var s = (n*1000000).toFixed(3);
 		if (s == "0.000") return s;
@@ -46,7 +46,7 @@ function adjNumN(n) {
 	if (an >= 100000) return n.toFixed(0);
 	else if (an >= 100) return n.toFixed(2);
 	else if (an >= 1) return n.toFixed(4);
-	else if (an > 0.0001) return n.toFixed(6);
+	else if (an >= 0.000001) return n.toFixed(6);
 	else {
 		if (an === 0) return an;
 		else {
@@ -69,7 +69,7 @@ function adjNumShort(n) {
 	var an = Math.abs(n);
 	if (an >= 10000000) return (n/1000000).toFixed(2).replace('.',"M");
 	else if (an >= 10000) return (n/1000).toFixed(2).replace('.',"k");
-	else if (an > 0.0001) {
+	else if (an >= 0.000001) {
 		var s = n.toFixed(6);
 		while (s[s.length-1] == '0') s = s.substr(0,s.length-1);
 		if (s && s[s.length-1] == '.') s = s.substr(0,s.length-1);


### PR DESCRIPTION
As long as the number can be represented by 6 decimal places, it shouldn't be contracted to "micro" representation as that makes visual comparison between such values much harder and without any real benefit.